### PR TITLE
map: move armoury in a place more accessible for bots

### DIFF
--- a/maps/chasm.map
+++ b/maps/chasm.map
@@ -10927,12 +10927,12 @@ shared_pk02/generic01a
 }
 {
 "classname" "team_human_armoury"
-"origin" "96.000000 -256.000000 24.000000"
+"origin" "320.000000 -256.000000 24.000000"
 "angle" "90.000000"
 }
 {
 "classname" "team_human_medistat"
-"origin" "176.000000 -192.000000 24.000000"
+"origin" "224.000000 -248.000000 24.000000"
 }
 {
 "classname" "team_human_mgturret"


### PR DESCRIPTION
- move armoury in a place more accessible for bots
- also move medistat with armoury to keep reload/heal combo

@bmorel do we still need such trick? is the actual armoury still not accessible with latest game code/daemonmap?